### PR TITLE
Submission validation pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1037,7 +1037,6 @@ dependencies = [
 [[package]]
 name = "mosaic-core"
 version = "0.6.99"
-source = "git+https://github.com/justinmoon/mosaic-core?branch=demo%2Fstep-1#c623df264debeaf75cb043d518048748e09de29c"
 dependencies = [
  "bitflags",
  "blake3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ tokio = { version = "1", features = [ "full" ] }
 [dev-dependencies]
 quinn = "0.11"
 [patch."https://github.com/mikedilger/mosaic-core"]
-# Use local checkout while iterating on Step 2
-mosaic-core = { path = "../mosaic-core" }
+# Use forked mosaic-core from justinmoon for this branch
+mosaic-core = { git = "https://github.com/justinmoon/mosaic-core", branch = "demo/step-2" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,5 +15,5 @@ tokio = { version = "1", features = [ "full" ] }
 [dev-dependencies]
 quinn = "0.11"
 [patch."https://github.com/mikedilger/mosaic-core"]
-# Point CI to the PR branch of mosaic-core
-mosaic-core = { git = "https://github.com/justinmoon/mosaic-core", branch = "demo/step-1" }
+# Use local checkout while iterating on Step 2
+mosaic-core = { path = "../mosaic-core" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@ pub use error::{Error, InnerError};
 mod handler;
 use handler::handle_mosaic_message;
 
+mod validation;
+pub use validation::{SubmissionValidationError, validate_submission};
+
 use std::sync::Arc;
 
 // use dashmap::DashMap;

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,0 +1,153 @@
+use crate::client::ClientData;
+
+use mosaic_core::{Error as CoreError, InnerError, Message, MessageType, OwnedRecord, ResultCode};
+
+/// Outcome of validating a Submission message before persistence.
+#[derive(Debug)]
+pub enum SubmissionValidationError {
+    /// Client attempted to submit a record before completing HELLO/HELLO ACK.
+    HandshakeNotComplete,
+    /// Message was not a Submission frame.
+    WrongMessageType,
+    /// Record failed structural or cryptographic verification.
+    RecordInvalid(CoreError),
+}
+
+impl SubmissionValidationError {
+    /// Map validation failures to the shared Mosaic `ResultCode` enumeration.
+    #[must_use]
+    pub fn result_code(&self) -> ResultCode {
+        match self {
+            SubmissionValidationError::HandshakeNotComplete
+            | SubmissionValidationError::WrongMessageType => ResultCode::Invalid,
+            SubmissionValidationError::RecordInvalid(err) => match err.inner {
+                InnerError::RecordTooLong => ResultCode::TooLarge,
+                _ => ResultCode::Invalid,
+            },
+        }
+    }
+}
+
+/// Validate a `Submission` message according to the Mosaic specification.
+///
+/// Returns an owned, verified record on success so downstream code can persist it.
+pub fn validate_submission(
+    message: &Message,
+    client: &ClientData,
+) -> Result<OwnedRecord, SubmissionValidationError> {
+    if message.message_type() != MessageType::Submission {
+        return Err(SubmissionValidationError::WrongMessageType);
+    }
+
+    if client.mosaic_version.is_none() || client.applications.is_none() {
+        return Err(SubmissionValidationError::HandshakeNotComplete);
+    }
+
+    let record_bytes = &message.as_bytes()[8..];
+    OwnedRecord::from_vec(record_bytes.to_vec()).map_err(SubmissionValidationError::RecordInvalid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
+
+    use mosaic_core::{
+        EMPTY_TAG_SET, Kind, OwnedRecord, RecordAddressData, RecordParts, RecordSigningData,
+        SecretKey, Timestamp,
+    };
+
+    fn client_addr() -> SocketAddr {
+        SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9000)
+    }
+
+    fn make_client(handshake_complete: bool) -> ClientData {
+        if handshake_complete {
+            ClientData {
+                remote_address: client_addr(),
+                peer: None,
+                mosaic_version: Some(0),
+                applications: Some(vec![0]),
+                closing_result: None,
+            }
+        } else {
+            ClientData {
+                remote_address: client_addr(),
+                peer: None,
+                mosaic_version: None,
+                applications: None,
+                closing_result: None,
+            }
+        }
+    }
+
+    fn build_record() -> OwnedRecord {
+        let signing_key = SecretKey::generate();
+        OwnedRecord::new(&RecordParts {
+            signing_data: RecordSigningData::SecretKey(signing_key.clone()),
+            address_data: RecordAddressData::Random(signing_key.public(), Kind::KEY_SCHEDULE),
+            timestamp: Timestamp::now().unwrap(),
+            flags: Default::default(),
+            tag_set: &EMPTY_TAG_SET,
+            payload: b"hello world",
+        })
+        .unwrap()
+    }
+
+    #[test]
+    fn submission_requires_handshake() {
+        let client = make_client(false);
+        let record = build_record();
+        let message = mosaic_core::Message::new_submission(&record).unwrap();
+
+        let err = validate_submission(&message, &client).unwrap_err();
+        assert!(matches!(
+            err,
+            SubmissionValidationError::HandshakeNotComplete
+        ));
+        assert_eq!(err.result_code(), ResultCode::Invalid);
+    }
+
+    #[test]
+    fn submission_wrong_type_rejected() {
+        let client = make_client(true);
+        let message = mosaic_core::Message::new_hello(0, &[]).unwrap();
+
+        let err = validate_submission(&message, &client).unwrap_err();
+        assert!(matches!(err, SubmissionValidationError::WrongMessageType));
+        assert_eq!(err.result_code(), ResultCode::Invalid);
+    }
+
+    #[test]
+    fn valid_submission_passes() {
+        let client = make_client(true);
+        let record = build_record();
+        let message = mosaic_core::Message::new_submission(&record).unwrap();
+
+        let validated = validate_submission(&message, &client).unwrap();
+        assert_eq!(validated.as_bytes(), record.as_bytes());
+    }
+
+    #[test]
+    fn invalid_record_is_caught() {
+        let client = make_client(true);
+        let record = build_record();
+        let message = mosaic_core::Message::new_submission(&record).unwrap();
+
+        let mut corrupted = message.as_bytes().to_vec();
+        // Flip a bit inside the record payload to break the signature/hash invariant.
+        corrupted[8] ^= 0xFF;
+        let invalid_message = unsafe { mosaic_core::Message::from_bytes_unchecked(corrupted) };
+
+        let err = validate_submission(&invalid_message, &client).unwrap_err();
+        assert!(matches!(err, SubmissionValidationError::RecordInvalid(_)));
+        assert_eq!(err.result_code(), ResultCode::Invalid);
+    }
+
+    #[test]
+    fn record_too_long_maps_to_toolarge() {
+        let err = SubmissionValidationError::RecordInvalid(InnerError::RecordTooLong.into_err());
+        assert_eq!(err.result_code(), ResultCode::TooLarge);
+    }
+}


### PR DESCRIPTION
Summary
- Introduces the submission validation pipeline to the server as a focused, test-covered module. This enforces that a client completes HELLO/HELLO ACK before submitting, and that submitted records are structurally and cryptographically valid per mosaic-core.

What’s included
- New module: src/validation.rs
  - validate_submission(&Message, &ClientData) -> Result<OwnedRecord, SubmissionValidationError>
  - Maps validation failures to unified ResultCode values:
    - HandshakeNotComplete, WrongMessageType -> INVALID
    - RecordTooLong -> TOO_LARGE; other record verification errors -> INVALID
- Public export in src/lib.rs for handler integration in a later step.
- Unit tests covering the validation rules (handshake prerequisite; wrong type; corrupted record invalidation; oversize mapping).
- Cargo updates to wire in mosaic-core locally during development and ensure tests run.

Spec alignment
- Record verification: mosaic-spec/docs/record.md (§Validation).
- Submission and result codes: mosaic-spec/docs/messages.md (§Submission, §Result Codes).
- Handshake prerequisite is enforced implicitly by requiring negotiated state in ClientData before accepting submissions (Hello/Hello Ack wire format already validated in mosaic-core).

Out of scope (deliberate)
- Storage/duplicate detection and wiring the store into the handler will come in a later step.
- Handler changes for Submission are not included here; this keeps the PR small and focused.

Notes
- Redundant HELLO behavior and incompatible-version Closing details are tracked outside this PR and do not impact the validation module.

